### PR TITLE
perf(cpu): enable native instructions and reuse executor worker pools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(GGMLC_ENABLE_CUDA "Enable CUDA backend in ggmlc" OFF)
 option(GGMLC_ENABLE_METAL "Enable Metal backend in ggmlc" OFF)
 option(GGMLC_BUILD_EXAMPLES "Build downstream application examples" ON)
+option(GGMLC_BUILD_TESTS "Build native runtime tests" OFF)
+
+if (GGMLC_BUILD_TESTS)
+    enable_testing()
+endif()
 
 # Includes
 include_directories(
@@ -93,6 +98,17 @@ else()
     endif()
 
     add_library(ggml_lib STATIC ${GGML_SOURCES})
+    option(GGML_NATIVE "Optimize GGML for the build machine's CPU" ON)
+    if (GGML_NATIVE AND NOT CMAKE_CROSSCOMPILING AND NOT MSVC
+        AND CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"
+        AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        # Match GGML's native CPU optimization for this standalone source build.
+        if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|i.86")
+            target_compile_options(ggml_lib PRIVATE -march=native)
+        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64|ARM64")
+            target_compile_options(ggml_lib PRIVATE -mcpu=native)
+        endif()
+    endif()
     target_compile_definitions(ggml_lib PUBLIC
         _GNU_SOURCE
         GGML_USE_CPU

--- a/README.md
+++ b/README.md
@@ -432,6 +432,16 @@ cmake -B build-cuda -DGGMLC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="all" -DCM
 cmake --build build-cuda -j$(nproc)
 ```
 
+CPU-only GCC/Clang builds optimize for the build machine by default. Use
+`-DGGML_NATIVE=OFF` when building for other CPUs. Native CPU flags are not added
+when cross-compiling. Each CPU executor reuses its worker threads across inference
+calls; set `n_threads` in Python or `--threads` in the CLI for your workload.
+
+To run the native CPU regression test, configure with `-DGGMLC_BUILD_TESTS=ON`,
+build the `test-executor-cpu` target, then run `ctest --test-dir build --output-on-failure`.
+`build/runtime/test-executor-cpu --benchmark` measures a small MLP through the
+model executor, including input and output copies.
+
 #### Windows (MSVC 2022 / Ninja)
 
 ```powershell

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -38,6 +38,12 @@ target_link_libraries(ggmlc-run PRIVATE
     ggmlc_runtime
 )
 
+if (GGMLC_BUILD_TESTS)
+    add_executable(test-executor-cpu ../tests/runtime/test_executor_cpu.cpp)
+    target_link_libraries(test-executor-cpu PRIVATE ggmlc_runtime)
+    add_test(NAME executor-cpu COMMAND test-executor-cpu)
+endif()
+
 # Shared library for C-FFI
 add_library(ggmlc_runtime_shared SHARED
     src/loader.cpp

--- a/runtime/include/ggmlc/executor.h
+++ b/runtime/include/ggmlc/executor.h
@@ -111,6 +111,8 @@ private:
     std::string device_ = "cpu";
     bool is_cuda_ = false;
     ggml_backend_t backend_ = nullptr;
+    ggml_threadpool_t cpu_threadpool_ = nullptr;
+    int cpu_threadpool_n_threads_ = 0;
 
     // Weights: static parameters & constants (allocated & initialized once)
     ggml_backend_buffer_t weight_buffer_ = nullptr;

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -97,6 +97,11 @@ ModelExecutor::ModelExecutor(const SerializedModelGraph& graph, const std::strin
 }
 
 ModelExecutor::~ModelExecutor() {
+    if (cpu_threadpool_) {
+        ggml_backend_cpu_set_threadpool(backend_, nullptr);
+        ggml_threadpool_free(cpu_threadpool_);
+        cpu_threadpool_ = nullptr;
+    }
     if (galloc_) {
         ggml_gallocr_free(galloc_);
         galloc_ = nullptr;
@@ -1758,6 +1763,21 @@ void ModelExecutor::run(int n_threads) {
         throw std::runtime_error("Executor not prepared. Call prepare() first.");
     }
     if (ggml_backend_is_cpu(backend_)) {
+        if (n_threads < 1 || n_threads > GGML_MAX_N_THREADS) {
+            throw std::invalid_argument("CPU thread count must be between 1 and " + std::to_string(GGML_MAX_N_THREADS));
+        }
+        if (!cpu_threadpool_ || cpu_threadpool_n_threads_ != n_threads) {
+            auto params = ggml_threadpool_params_default(n_threads);
+            auto new_pool = ggml_threadpool_new(&params);
+            if (!new_pool) {
+                throw std::runtime_error("Failed to create CPU thread pool");
+            }
+            // Detach the previous pool before freeing it; the backend borrows it.
+            ggml_backend_cpu_set_threadpool(backend_, new_pool);
+            if (cpu_threadpool_) ggml_threadpool_free(cpu_threadpool_);
+            cpu_threadpool_ = new_pool;
+            cpu_threadpool_n_threads_ = n_threads;
+        }
         ggml_backend_cpu_set_n_threads(backend_, n_threads);
     }
 

--- a/tests/runtime/test_executor_cpu.cpp
+++ b/tests/runtime/test_executor_cpu.cpp
@@ -1,0 +1,124 @@
+#include "ggmlc/executor.h"
+#include "ggml-cpu.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+static void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+struct MLP {
+    ggmlc::SerializedModelGraph graph;
+    std::vector<float> weights;
+    int dim;
+
+    explicit MLP(int width) : weights(width * width), dim(width) {
+        for (size_t i = 0; i < weights.size(); ++i) {
+            weights[i] = float(int(i % 31) - 15) / (31 * std::sqrt(float(dim)));
+        }
+        graph.name = "cpu_test_mlp";
+        graph.symbol_table = {"rows"};
+        graph.inputs = {0};
+        graph.outputs = {4};
+        graph.parameters = {1};
+        for (uint32_t id = 0; id < 5; ++id) {
+            ggmlc::SerializedTensor t{};
+            t.id = id;
+            t.name = "tensor_" + std::to_string(id);
+            t.type = GGML_TYPE_F32;
+            t.storage = id == 0 ? ggmlc::StorageClass::INPUT :
+                        id == 1 ? ggmlc::StorageClass::PARAMETER : ggmlc::StorageClass::ACTIVATION;
+            for (int d = 0; d < 4; ++d) {
+                t.ne[d] = std::make_shared<ggmlc::DimExpr>();
+                t.ne[d]->type = ggmlc::DimType::STATIC;
+                t.ne[d]->val = d == 0 ? dim : 1;
+            }
+            if (id == 1) {
+                t.ne[1]->val = dim;
+                t.data_ptr = reinterpret_cast<const uint8_t*>(weights.data());
+                t.data_size = weights.size() * sizeof(float);
+            } else {
+                t.ne[1]->type = ggmlc::DimType::SYMBOL;
+                t.ne[1]->val = 0;
+            }
+            graph.tensors[id] = t;
+        }
+        graph.ops = {
+            {0, GGML_OP_MUL_MAT, "linear1", {1, 0}, {2}, {}, {}},
+            {1, GGML_OP_UNARY, "relu", {2}, {3}, {{"unary_op", GGML_UNARY_OP_RELU}}, {}},
+            {2, GGML_OP_MUL_MAT, "linear2", {1, 3}, {4}, {}, {}},
+        };
+    }
+
+    void check(const std::vector<float>& input, const float* output) const {
+        std::vector<double> hidden(dim);
+        for (size_t row = 0; row < input.size() / dim; ++row) {
+            for (int j = 0; j < dim; ++j) {
+                double sum = 0;
+                for (int k = 0; k < dim; ++k) sum += weights[j * dim + k] * double(input[row * dim + k]);
+                hidden[j] = std::max(0.0, sum);
+            }
+            for (int j = 0; j < dim; ++j) {
+                double sum = 0;
+                for (int k = 0; k < dim; ++k) sum += weights[j * dim + k] * hidden[k];
+                require(std::abs(output[row * dim + j] - sum) < 1e-4, "MLP output mismatch");
+            }
+        }
+    }
+};
+
+static std::vector<float> make_input(int rows, int dim, int seed) {
+    std::vector<float> input(rows * dim);
+    for (size_t i = 0; i < input.size(); ++i) input[i] = float(int((i + seed) % 17) - 8) / 17;
+    return input;
+}
+
+int main(int argc, char** argv) {
+    const bool benchmark = argc == 2 && std::string(argv[1]) == "--benchmark";
+    MLP model(benchmark ? 1024 : 32);
+    for (int repeat = 0; repeat < (benchmark ? 1 : 3); ++repeat) {
+        ggmlc::ModelExecutor executor(model.graph, "cpu");
+        for (int rows : {1, 64, 1}) {
+            for (int threads : {1, 4, 2, 1}) {
+                auto input = make_input(rows, model.dim, threads + repeat);
+                std::vector<double> times;
+                for (int i = 0; i < (benchmark ? 60 : 3); ++i) {
+                    const auto start = std::chrono::steady_clock::now();
+                    executor.prepare({{"rows", rows}});
+                    executor.set_input(0, input.data(), input.size() * sizeof(float));
+                    executor.run(threads);
+                    const auto* output = static_cast<const float*>(executor.get_output_data(4));
+                    const auto stop = std::chrono::steady_clock::now();
+                    if (!benchmark || i == 0) model.check(input, output);
+                    if (i >= 10) times.push_back(std::chrono::duration<double, std::micro>(stop - start).count());
+                }
+                if (benchmark) {
+                    std::sort(times.begin(), times.end());
+                    std::cout << "rows=" << rows << " threads=" << threads
+                              << " median_us=" << times[times.size() / 2] << '\n';
+                }
+            }
+        }
+        if (!benchmark) {
+            for (int invalid_threads : {0, -1, GGML_MAX_N_THREADS + 1}) {
+                bool rejected = false;
+                try {
+                    executor.run(invalid_threads);
+                } catch (const std::invalid_argument&) {
+                    rejected = true;
+                }
+                require(rejected, "Invalid CPU thread count was accepted");
+            }
+            // A rejected call must leave the executor usable.
+            auto input = make_input(1, model.dim, 1 + repeat);
+            executor.set_input(0, input.data(), input.size() * sizeof(float));
+            executor.run(2);
+            model.check(input, static_cast<const float*>(executor.get_output_data(4)));
+        }
+    }
+    std::cout << "CPU inference checks passed; AVX2=" << ggml_cpu_has_avx2()
+              << " AVX512=" << ggml_cpu_has_avx512() << '\n';
+}


### PR DESCRIPTION
CPU-only builds currently assemble GGML sources without native architecture flags, and each `ModelExecutor::run()` leaves GGML to create and destroy a temporary CPU thread pool. This adds avoidable compute and dispatch costs to repeated inference.

This change enables native CPU instructions for supported GCC/Clang CPU-only builds and keeps one worker pool per executor. The local synthetic MLP benchmark improved by approximately **3.6x for one input row** and **6.2x for 64 input rows**, using four threads. These are model-executor measurements, not full-LLM results or a llama.cpp comparison.

## Changes

- Honor `GGML_NATIVE` in the standalone CPU source build, enabling `-march=native` on x86 and `-mcpu=native` on ARM. Skip these additions when cross-compiling or using MSVC; retain the existing Apple native-build override. `-DGGML_NATIVE=OFF` opts out for distribution to other CPUs.
- Lazily create a CPU worker pool, reuse it across inference and graph preparation, and replace it when the requested thread count changes. Detach pools before freeing them and release the pool during executor destruction.
- Reject CPU thread counts outside `1..GGML_MAX_N_THREADS` with an exception.
- Add an optional native CTest target and `--benchmark` mode, plus build and benchmark instructions in the README.

## Measurements

AMD Ryzen 9 9955HX, GCC 15.2.0 through the existing Conda toolchain, Release builds, four CPU threads. The original build inherited `-march=nocona` and reported AVX2/AVX512 disabled; the native build reported both enabled.

| Input rows | Original | Persistent pool, native flags disabled | Persistent pool + native flags | Combined speedup |
| --- | ---: | ---: | ---: | ---: |
| 1 | 74.460 us | 38.272 us | 20.619 us | 3.6x |
| 64 | 2174.040 us | 2113.740 us | 347.934 us | 6.2x |

The benchmark is a synthetic F32 `linear -> ReLU -> linear` model with width 1024 and shared weights, run through `ModelExecutor`. Timings include `prepare()`, input copy, synchronous execution, and output copy. Each case uses 10 warmups and 50 measured calls; values above are the first measured case's median for each shape. Numerical reference evaluation is outside the timed interval. Baseline was built from `af7b137` and exercised with the same benchmark workload before the runtime changes.

Weights fit in cache, CPU affinity/frequency were not fixed, and runs were not randomized. Actual LLM gains will depend on model size, quantization, context length, and graph preparation costs. No full-LLM or GPU speedup is claimed.

## Validation

- Native CPU CLI built successfully.
- CTest passed with `GGML_NATIVE=ON` and `GGML_NATIVE=OFF`.
- Tests check outputs against a double-precision reference, repeated inference, thread-count changes, shape changes, executor destruction/recreation, invalid thread counts, and successful inference after rejected calls.
- All three benchmark variants passed their numerical checks.
- `git diff --check` passed.
- Python tests were not run because PyTorch, pytest, nanobind, and the built extension were unavailable. GPU tests were not run because a working NVIDIA driver was unavailable. ARM, MSVC, and cross-compilation were not exercised locally.

Reproduce the optimized build and test:

```sh
cmake -S . -B build-perf -DCMAKE_BUILD_TYPE=Release -DGGMLC_BUILD_EXAMPLES=OFF -DGGMLC_BUILD_TESTS=ON -DGGML_NATIVE=ON
cmake --build build-perf --target ggmlc-run test-executor-cpu -j 8
ctest --test-dir build-perf --output-on-failure
./build-perf/runtime/test-executor-cpu --benchmark
```

Configure a separate build with `-DGGML_NATIVE=OFF` to measure the pool change without native instructions.
